### PR TITLE
ignore attributes to avoid data.table version dependency

### DIFF
--- a/tests/testthat/test_prep_func.R
+++ b/tests/testthat/test_prep_func.R
@@ -9,5 +9,5 @@ test_that("prepare_data() works", {
   test_obj <- create_test_data()
 
   # Checks for equality -----------------------------------------------------
-  expect_equal(test_obj, corporaexplorer::test_data)
+  expect_equal(test_obj, corporaexplorer::test_data, check.attributes = FALSE)
 })


### PR DESCRIPTION
Closes #32. As noted there, this might not be ideal, but it does work.